### PR TITLE
chore: fix package manager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9.6.0
           run_install: false
 
       - name: Setup Node.js 20

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -15,13 +15,5 @@
   "license": "ISC",
   "devDependencies": {
     "vitepress": "1.0.0-rc.13"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "ignoreMissing": [
-        "@algolia/client-search",
-        "search-insights"
-      ]
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "engines": {
     "node": ">=14.0.0",
-    "pnpm": ">=7"
+    "pnpm": ">=8"
   },
-  "packageManager": "pnpm@8.15.5+sha256.4b4efa12490e5055d59b9b9fc9438b7d581a6b7af3b5675eb5c5f447cee1a589"
+  "packageManager": "pnpm@9.12.2"
 }


### PR DESCRIPTION
We were getting errors when there was a mismatch between the `packageManager` and version field from the `pnpm/setup-action`. this resolves it by removing the version from action and letting the `packageManager` be used to decide the version.
Furthermore, i have also updated the pnpm version to `v9.12.2`