### PR TITLE
refactor: use hono factories in hono adaptor

### DIFF
--- a/.changeset/fifty-tips-deliver.md
+++ b/.changeset/fifty-tips-deliver.md
@@ -1,0 +1,5 @@
+---
+"@disci/adapter-hono": major
+---
+
+Introduce new adapter for hono framework

--- a/apps/node-hono-example/package.json
+++ b/apps/node-hono-example/package.json
@@ -17,7 +17,7 @@
     "discord-api-types": "^0.37.78",
     "discord-verify": "^1.2.0",
     "dotenv": "^16.0.3",
-    "hono": "^4.2.5"
+    "hono": "^4.6.8"
   },
   "devDependencies": {
     "@types/node": "^20.12.3",

--- a/apps/node-hono-example/src/index.ts
+++ b/apps/node-hono-example/src/index.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { createRequestHandler } from "@disci/adapter-hono";
+import { createInteractionRequestHandler } from "@disci/adapter-hono";
 import { serve } from "@hono/node-server";
 import { EventNames, InteractionHandler } from "disci";
 import { ButtonStyle, ComponentType } from "discord-api-types/v10";
@@ -67,7 +67,7 @@ app.get("/", (c) => c.text("Server is running 🚀"));
 // we are adding it to /interactions path instead of root
 // ensure that when you enter the url into discord dev portal
 // to append "/interactions" to the url
-app.post("/interactions", createRequestHandler(handler));
+app.post("/interactions", ...createInteractionRequestHandler(handler));
 
 serve({
 	fetch: app.fetch,

--- a/packages/adapter-hono/.npmignore
+++ b/packages/adapter-hono/.npmignore
@@ -2,3 +2,8 @@ index.ts
 
 tsup.config.ts
 tsconfig.json
+# Ignore changeset changelogs
+CHANGELOG.md
+
+# tools
+.turbo

--- a/packages/adapter-hono/LICENSE
+++ b/packages/adapter-hono/LICENSE
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 imayuru
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/adapter-hono/README.md
+++ b/packages/adapter-hono/README.md
@@ -15,7 +15,7 @@ bun add @disci/adapter-hono
 # Usage
 
 ```typescript
-import { createRequestHandler } from "@disci/adapter-hono";
+import { createInteractionRequestHandler } from "@disci/adapter-hono";
 import { InteractionHandler } from "disci";
 import { Hono } from "hono";
 
@@ -27,7 +27,7 @@ const handler = new InteractionHandler({
 
 const app = new Hono();
 
-app.post("/interactions", ...createRequestHandler(handler));
+app.post("/interactions", ...createInteractionRequestHandler(handler));
 
 // please refer to hono documentation for your platform
 // on how to serve the app

--- a/packages/adapter-hono/README.md
+++ b/packages/adapter-hono/README.md
@@ -1,0 +1,64 @@
+# disci/adapter-hono
+
+Adapter to use [disci](https://github.com/typicalninja/disci) with [hono](https://hono.dev/) webserver.
+
+# Installation
+
+```bash
+npm install @disci/adapter-hono
+# or if you use pnpm, yarn or bun
+pnpm add @disci/adapter-hono
+yarn add @disci/adapter-hono
+bun add @disci/adapter-hono
+```
+
+# Usage
+
+```typescript
+import { createRequestHandler } from "@disci/adapter-hono";
+import { InteractionHandler } from "disci";
+import { Hono } from "hono";
+
+const handler = new InteractionHandler({
+  // ensure you have the PUBLIC_KEY in your environment
+  publicKey: process.env.PUBLIC_KEY,
+  cryptoEngine: crypto.subtle,
+});
+
+const app = new Hono();
+
+app.post("/interactions", createRequestHandler(handler));
+
+// please refer to hono documentation for your platform
+// on how to serve the app
+export default app;
+```
+
+## Or 
+
+or use `toGenericRequest` to convert a hono [`context`](https://hono.dev/docs/api/context) (request) into a object that can be used by disci.
+
+```typescript
+import { toGenericRequest } from "@disci/adapter-hono";
+// same imports as above
+
+app.post("/interactions", async (ctx) => {
+  const request = await toGenericRequest(ctx);
+  const response = await handler.handleRequest(request);
+  return ctx.json(response);
+});
+
+export default app;
+```
+
+
+# Hono version compatibility
+
+| Adapter version | Hono version | Disci version |
+| --------------- | ------------ | ------------- |
+| 1.x.x           | 4.x.x        | 1.x.x         |
+
+
+# License
+
+This repository and the code inside it is licensed under the Apache-2.0 License. Read [LICENSE](https://github.com/typicalninja/disci/blob/main/LICENSE) for more information.

--- a/packages/adapter-hono/README.md
+++ b/packages/adapter-hono/README.md
@@ -1,6 +1,6 @@
 # disci/adapter-hono
 
-Adapter to use [disci](https://github.com/typicalninja/disci) with [hono](https://hono.dev/) webserver.
+Adapter to use [disci](https://github.com/typicalninja/disci) with [hono](https://hono.dev/) framework.
 
 # Installation
 

--- a/packages/adapter-hono/README.md
+++ b/packages/adapter-hono/README.md
@@ -27,7 +27,7 @@ const handler = new InteractionHandler({
 
 const app = new Hono();
 
-app.post("/interactions", createRequestHandler(handler));
+app.post("/interactions", ...createRequestHandler(handler));
 
 // please refer to hono documentation for your platform
 // on how to serve the app
@@ -54,9 +54,9 @@ export default app;
 
 # Hono version compatibility
 
-| Adapter version | Hono version | Disci version |
-| --------------- | ------------ | ------------- |
-| 1.x.x           | 4.x.x        | 1.x.x         |
+| Adapter version |      Hono version     | Disci version |
+| --------------- | --------------------- | ------------- |
+| 1.x.x           | 4.x.x (uses: 4.6.6)   | 1.x.x         |
 
 
 # License

--- a/packages/adapter-hono/index.ts
+++ b/packages/adapter-hono/index.ts
@@ -49,7 +49,7 @@ export async function toGenericRequest<C extends Ctx>(
  * @example
  * ```ts
  * const handler = new InteractionHandler(...);
- * app.post("/interactions", createRequestHandler(handler));
+ * app.post("/interactions", ...createRequestHandler(handler));
  * ```
  * @param handler - The disci interaction handler
  */

--- a/packages/adapter-hono/index.ts
+++ b/packages/adapter-hono/index.ts
@@ -1,5 +1,38 @@
-import { DiscordVerifyHeaders, type InteractionHandler } from "disci";
+import {
+	DiscordVerifyHeaders,
+	type GenericRequest,
+	type InteractionHandler,
+} from "disci";
+import type { Context } from "hono";
 import { createFactory } from "hono/factory";
+
+/**
+ * Converts a Hono context to a generic request object
+ * @example
+ * ```ts
+ * const handler = new InteractionHandler(...);
+ * const app = new Hono();
+ *
+ * app.post("/interactions", async (c) => handler.handleRequest(await toGenericRequest(c)));
+ * ```
+ * @param c - The Hono context
+ * @returns
+ */
+export async function toGenericRequest(c: Context): Promise<GenericRequest> {
+	const signature = c.req.header(DiscordVerifyHeaders.signature) ?? "";
+
+	const timestamp = c.req.header(DiscordVerifyHeaders.timestamp) ?? "";
+
+	return {
+		body: await c.req.text(),
+
+		headers: {
+			[DiscordVerifyHeaders.signature]: signature,
+
+			[DiscordVerifyHeaders.timestamp]: timestamp,
+		},
+	};
+}
 
 export function createRequestHandler(handler: InteractionHandler) {
 	const factory = createFactory();
@@ -39,6 +72,5 @@ export function createRequestHandler(handler: InteractionHandler) {
 			c.status(500);
 			return c.json({ e: "Internal server error occurred" });
 		}
-	})[// the user will be able to do: createRequestHandler(handler) instead of ...createRequestHandler(handler); // return the first handler
-	0];
+	})[0]; // the user will be able to do: createRequestHandler(handler) instead of ...createRequestHandler(handler); // return the first handler
 }

--- a/packages/adapter-hono/index.ts
+++ b/packages/adapter-hono/index.ts
@@ -21,7 +21,9 @@ type Ctx = {
  * @example
  * ```ts
  * const handler = new InteractionHandler(...);
- * app.post("/interactions", async (c) => c.json(await handler.handleRequest(await toGenericRequest(c))));
+ * app.post("/interactions", async (c) =>
+ * 	c.json(await handler.handleRequest(await toGenericRequest(c)))
+ * );
  * ```
  * @param context - The Hono context
  */
@@ -45,15 +47,16 @@ export async function toGenericRequest<C extends Ctx>(
 }
 
 /**
- * Create a request handler for Hono using the provided interaction handler
+ * Create a request handler for a HTTPInteractionHandler instance
+ * Used to handle incoming requests from hono server
  * @example
  * ```ts
  * const handler = new InteractionHandler(...);
- * app.post("/interactions", ...createRequestHandler(handler));
+ * app.post("/interactions", ...createInteractionRequestHandler(handler));
  * ```
  * @param handler - The disci interaction handler
  */
-export function createRequestHandler(handler: InteractionHandler) {
+export function createInteractionRequestHandler(handler: InteractionHandler) {
 	const factory = createFactory();
 
 	return factory.createHandlers(async (c) => {

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@disci/adapter-hono",
-  "version": "1.0.0-alpha",
-  "description": "DisciJS adapter for hono http library",
+  "version": "0.0.0",
+  "description": "DisciJS adapter for hono framework",
   "type": "module",
   "exports": "./dist/index.js",
   "types": "./dist/index.d.js",
@@ -9,11 +9,11 @@
     "build": "tsup",
     "dev": "tsup --watch"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": ["disci", "hono", "disci-adapter"],
+  "author": "typicalninja",
+  "license": "Apache-2.0",
   "dependencies": {
-    "disci": "workspace:*",
+    "disci": "workspace:^",
     "hono": "^4.2.5"
   }
 }

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "hono": "^3.5.4",
-    "disci": "workspace:*"
+    "disci": "workspace:*",
+    "hono": "^4.2.5"
   }
 }

--- a/packages/adapter-hono/package.json
+++ b/packages/adapter-hono/package.json
@@ -9,11 +9,15 @@
     "build": "tsup",
     "dev": "tsup --watch"
   },
-  "keywords": ["disci", "hono", "disci-adapter"],
+  "keywords": [
+    "disci",
+    "hono",
+    "disci-adapter"
+  ],
   "author": "typicalninja",
   "license": "Apache-2.0",
   "dependencies": {
     "disci": "workspace:^",
-    "hono": "^4.2.5"
+    "hono": "^4.6.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: ^16.0.3
         version: 16.0.3
       hono:
-        specifier: ^4.2.5
-        version: 4.2.5
+        specifier: ^4.6.8
+        version: 4.6.8
     devDependencies:
       '@types/node':
         specifier: ^20.12.3
@@ -1496,8 +1496,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.13.0:
-    resolution: {integrity: sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==}
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -2358,12 +2358,12 @@ packages:
     resolution: {integrity: sha512-GrRBIJhZ+tG+8RtoyPQjvqPGwppERmayyTiPKano4egmpkJf1XiptESUYK5vKHICNaJksAKB9jzy1CmOdQENPA==}
     engines: {node: '>=16.0.0'}
 
-  hono@4.2.5:
-    resolution: {integrity: sha512-uonJD3i/yy005kQ7bPZRVfG3rejYJwyPqBmPoUGijS4UB/qM+YlrZ7xzSWy+ByDu9buGHUG+f+SKzz03Y6V1Kw==}
-    engines: {node: '>=16.0.0'}
-
   hono@4.6.6:
     resolution: {integrity: sha512-euUj5qwvtkG+p38GFs0LYacwaoS2hYRAGn9ysAggiwT2QBcPnT1XYUCW3hatW4C1KzAXTYuQ08BlVDJtAGuhlg==}
+    engines: {node: '>=16.9.0'}
+
+  hono@4.6.8:
+    resolution: {integrity: sha512-f+2Ec9JAzabT61pglDiLJcF/DjiSefZkjCn9bzm1cYLGkD5ExJ3Jnv93ax9h0bn7UPLHF81KktoyjdQfWI2n1Q==}
     engines: {node: '>=16.9.0'}
 
   http-cache-semantics@4.1.1:
@@ -4894,12 +4894,12 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.13.0
+      acorn: 8.14.0
     optional: true
 
   acorn@8.10.0: {}
 
-  acorn@8.13.0:
+  acorn@8.14.0:
     optional: true
 
   ajv-formats@2.1.1(ajv@8.17.1):
@@ -5849,9 +5849,9 @@ snapshots:
 
   hono@3.5.4: {}
 
-  hono@4.2.5: {}
-
   hono@4.6.6: {}
+
+  hono@4.6.8: {}
 
   http-cache-semantics@4.1.1: {}
 
@@ -6806,7 +6806,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 17.0.45
-      acorn: 8.13.0
+      acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -6825,7 +6825,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.14.2
-      acorn: 8.13.0
+      acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,9 +94,15 @@ importers:
 
   apps/test:
     dependencies:
+      '@disci/adapter-hono':
+        specifier: workspace:*
+        version: link:../../packages/adapter-hono
       '@discordjs/builders':
         specifier: ^1.6.1
         version: 1.6.1
+      '@hono/node-server':
+        specifier: ^1.11.0
+        version: 1.11.0
       disci:
         specifier: workspace:^
         version: link:../../packages/disci
@@ -112,25 +118,16 @@ importers:
       fastify-raw-body:
         specifier: ^4.2.0
         version: 4.3.0
+      hono:
+        specifier: ^4.6.6
+        version: 4.6.6
     devDependencies:
       '@types/node':
         specifier: ^18.13.0
         version: 18.14.2
-      autoprefixer:
-        specifier: ^10.4.13
-        version: 10.4.20(postcss@8.4.29)
-      nodemon:
-        specifier: ^2.0.20
-        version: 2.0.22
-      postcss:
-        specifier: ^8.4.21
-        version: 8.4.29
-      ts-node:
-        specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.14.2)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+      tsx:
+        specifier: ^4.7.2
+        version: 4.7.2
 
   apps/website:
     devDependencies:
@@ -141,11 +138,11 @@ importers:
   packages/adapter-hono:
     dependencies:
       disci:
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../disci
       hono:
-        specifier: ^4.2.5
-        version: 4.2.5
+        specifier: ^4.6.6
+        version: 4.6.6
 
   packages/create-disci:
     dependencies:
@@ -1197,6 +1194,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
@@ -1487,8 +1487,17 @@ packages:
     resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
 
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
   acorn@8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.13.0:
+    resolution: {integrity: sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1602,13 +1611,6 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
-  autoprefixer@10.4.20:
-    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-
   avvio@8.4.0:
     resolution: {integrity: sha512-CDSwaxINFy59iNwhYnkvALBwZiTydGkOecZyPkqBpABYR1KqGEsET0VOOYDwtleZSUIdeY36DC2bSZ24CO1igA==}
 
@@ -1650,11 +1652,6 @@ packages:
   braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
-
-  browserslist@4.24.0:
-    resolution: {integrity: sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
-    hasBin: true
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1699,9 +1696,6 @@ packages:
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
-
-  caniuse-lite@1.0.30001669:
-    resolution: {integrity: sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==}
 
   capnp-ts@0.7.0:
     resolution: {integrity: sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==}
@@ -1854,14 +1848,6 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
-  debug@3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -1932,9 +1918,6 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  electron-to-chromium@1.5.40:
-    resolution: {integrity: sha512-LYm78o6if4zTasnYclgQzxEcgMoIcybWOhkATWepN95uwVVWV0/IW10v+2sIeHE+bIYWipLneTftVyQm45UY7g==}
 
   emoji-regex@7.0.3:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
@@ -2129,10 +2112,6 @@ packages:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
 
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
-
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
@@ -2282,9 +2261,6 @@ packages:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
 
-  fraction.js@4.3.7:
-    resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
-
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -2386,6 +2362,10 @@ packages:
     resolution: {integrity: sha512-uonJD3i/yy005kQ7bPZRVfG3rejYJwyPqBmPoUGijS4UB/qM+YlrZ7xzSWy+ByDu9buGHUG+f+SKzz03Y6V1Kw==}
     engines: {node: '>=16.0.0'}
 
+  hono@4.6.6:
+    resolution: {integrity: sha512-euUj5qwvtkG+p38GFs0LYacwaoS2hYRAGn9ysAggiwT2QBcPnT1XYUCW3hatW4C1KzAXTYuQ08BlVDJtAGuhlg==}
+    engines: {node: '>=16.9.0'}
+
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
 
@@ -2414,9 +2394,6 @@ packages:
   iftype@4.0.9:
     resolution: {integrity: sha512-01Klo+04dkDzY193D1GVfOdQzmpqaYFJTAlZKRztkT/BOaU7sSnvxGimSln+7DMqLUP4tpDTNFgxqVPLYZVypA==}
     engines: {node: '>=8', npm: '>=5'}
-
-  ignore-by-default@1.0.1:
-    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
 
   ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
@@ -2816,20 +2793,8 @@ packages:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
 
-  node-releases@2.0.18:
-    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
-
-  nodemon@2.0.22:
-    resolution: {integrity: sha512-B8YqaKMmyuCO7BowF1Z1/mkPqLk6cs/l63Ojtd6otKjMx47Dq1utxfRxcavH1I7VSaL8n5BUaoutadnsX3AAVQ==}
-    engines: {node: '>=8.10.0'}
-    hasBin: true
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
-  normalize-range@0.1.2:
-    resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
   npm-run-path@4.0.1:
@@ -3021,9 +2986,6 @@ packages:
       yaml:
         optional: true
 
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
-
   postcss@8.4.29:
     resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3056,9 +3018,6 @@ packages:
 
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
-
-  pstree.remy@1.1.8:
-    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
 
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
@@ -3204,14 +3163,6 @@ packages:
     resolution: {integrity: sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==}
     engines: {node: '>=10'}
 
-  semver@5.7.1:
-    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
-    hasBin: true
-
-  semver@7.0.0:
-    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==}
-    hasBin: true
-
   semver@7.5.4:
     resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
     engines: {node: '>=10'}
@@ -3262,10 +3213,6 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
-  simple-update-notifier@1.1.0:
-    resolution: {integrity: sha512-VpsrsJSUcJEseSbMHkrsrAVSdvVS5I96Qo1QAQ4FxQ9wXFcB+pjj7FB7/us9+GcgfW4ziHtYMc1J0PLczb55mg==}
-    engines: {node: '>=8.10.0'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -3447,10 +3394,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  touch@3.1.1:
-    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
-    hasBin: true
-
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -3607,9 +3550,6 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undefsafe@2.0.5:
-    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
-
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
@@ -3628,12 +3568,6 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-
-  update-browserslist-db@1.1.1:
-    resolution: {integrity: sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==}
-    hasBin: true
-    peerDependencies:
-      browserslist: '>= 4.21.0'
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -4301,6 +4235,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@discordjs/builders@1.6.1':
     dependencies:
@@ -4667,6 +4602,9 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
+  '@jridgewell/sourcemap-codec@1.5.0':
+    optional: true
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -4675,7 +4613,8 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/sourcemap-codec': 1.5.0
+    optional: true
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4761,13 +4700,17 @@ snapshots:
       fast-deep-equal: 3.1.3
       lodash: 4.17.21
 
-  '@tsconfig/node10@1.0.11': {}
+  '@tsconfig/node10@1.0.11':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@types/body-parser@1.19.2':
     dependencies:
@@ -4949,7 +4892,15 @@ snapshots:
 
   acorn-walk@8.2.0: {}
 
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.13.0
+    optional: true
+
   acorn@8.10.0: {}
+
+  acorn@8.13.0:
+    optional: true
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -5016,7 +4967,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -5051,16 +5003,6 @@ snapshots:
   async@1.5.2: {}
 
   atomic-sleep@1.0.0: {}
-
-  autoprefixer@10.4.20(postcss@8.4.29):
-    dependencies:
-      browserslist: 4.24.0
-      caniuse-lite: 1.0.30001669
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.4.29
-      postcss-value-parser: 4.2.0
 
   avvio@8.4.0:
     dependencies:
@@ -5112,13 +5054,6 @@ snapshots:
     dependencies:
       fill-range: 7.0.1
 
-  browserslist@4.24.0:
-    dependencies:
-      caniuse-lite: 1.0.30001669
-      electron-to-chromium: 1.5.40
-      node-releases: 2.0.18
-      update-browserslist-db: 1.1.1(browserslist@4.24.0)
-
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -5152,8 +5087,6 @@ snapshots:
   callsites@3.1.0: {}
 
   camelcase@5.3.1: {}
-
-  caniuse-lite@1.0.30001669: {}
 
   capnp-ts@0.7.0:
     dependencies:
@@ -5312,7 +5245,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   cross-spawn@5.1.0:
     dependencies:
@@ -5337,12 +5271,6 @@ snapshots:
 
   data-uri-to-buffer@2.0.2: {}
 
-  debug@3.2.7(supports-color@5.5.0):
-    dependencies:
-      ms: 2.1.2
-    optionalDependencies:
-      supports-color: 5.5.0
-
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
@@ -5365,7 +5293,8 @@ snapshots:
 
   detect-libc@2.0.2: {}
 
-  diff@4.0.2: {}
+  diff@4.0.2:
+    optional: true
 
   dir-glob@3.0.1:
     dependencies:
@@ -5386,8 +5315,6 @@ snapshots:
   dotenv@16.0.3: {}
 
   eastasianwidth@0.2.0: {}
-
-  electron-to-chromium@1.5.40: {}
 
   emoji-regex@7.0.3: {}
 
@@ -5633,8 +5560,6 @@ snapshots:
 
   escalade@3.1.1: {}
 
-  escalade@3.2.0: {}
-
   escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@4.0.0: {}
@@ -5807,8 +5732,6 @@ snapshots:
 
   forwarded@0.2.0: {}
 
-  fraction.js@4.3.7: {}
-
   fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
@@ -5928,6 +5851,8 @@ snapshots:
 
   hono@4.2.5: {}
 
+  hono@4.6.6: {}
+
   http-cache-semantics@4.1.1: {}
 
   http-errors@2.0.0:
@@ -5953,8 +5878,6 @@ snapshots:
       babel-runtime: 6.26.0
 
   iftype@4.0.9: {}
-
-  ignore-by-default@1.0.1: {}
 
   ignore@5.2.4: {}
 
@@ -6203,7 +6126,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   mark.js@8.11.1: {}
 
@@ -6308,24 +6232,7 @@ snapshots:
 
   node-forge@1.3.1: {}
 
-  node-releases@2.0.18: {}
-
-  nodemon@2.0.22:
-    dependencies:
-      chokidar: 3.5.3
-      debug: 3.2.7(supports-color@5.5.0)
-      ignore-by-default: 1.0.1
-      minimatch: 3.1.2
-      pstree.remy: 1.1.8
-      semver: 5.7.1
-      simple-update-notifier: 1.1.0
-      supports-color: 5.5.0
-      touch: 3.1.1
-      undefsafe: 2.0.5
-
   normalize-path@3.0.0: {}
-
-  normalize-range@0.1.2: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -6476,8 +6383,6 @@ snapshots:
       jiti: 1.21.6
       postcss: 8.4.29
 
-  postcss-value-parser@4.2.0: {}
-
   postcss@8.4.29:
     dependencies:
       nanoid: 3.3.6
@@ -6515,8 +6420,6 @@ snapshots:
       ipaddr.js: 1.9.1
 
   pseudomap@1.0.2: {}
-
-  pstree.remy@1.1.8: {}
 
   pump@3.0.0:
     dependencies:
@@ -6665,10 +6568,6 @@ snapshots:
     dependencies:
       node-forge: 1.3.1
 
-  semver@5.7.1: {}
-
-  semver@7.0.0: {}
-
   semver@7.5.4:
     dependencies:
       lru-cache: 6.0.0
@@ -6711,10 +6610,6 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-
-  simple-update-notifier@1.1.0:
-    dependencies:
-      semver: 7.0.0
 
   sisteransi@1.0.5: {}
 
@@ -6891,8 +6786,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  touch@3.1.1: {}
-
   tr46@0.0.3: {}
 
   tr46@1.0.1:
@@ -6913,8 +6806,8 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 17.0.45
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
+      acorn: 8.13.0
+      acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
@@ -6924,24 +6817,6 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@18.14.2)(typescript@4.9.5):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.14.2
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.5
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-
   ts-node@10.9.2(@types/node@18.14.2)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -6950,8 +6825,8 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 18.14.2
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
+      acorn: 8.13.0
+      acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
@@ -7091,8 +6966,6 @@ snapshots:
   uglify-js@3.17.4:
     optional: true
 
-  undefsafe@2.0.5: {}
-
   undici-types@5.26.5: {}
 
   undici@5.22.1:
@@ -7105,17 +6978,12 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  update-browserslist-db@1.1.1(browserslist@4.24.0):
-    dependencies:
-      browserslist: 4.24.0
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   vite@4.4.9(@types/node@20.12.7):
     dependencies:
@@ -7314,7 +7182,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@1.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: workspace:*
         version: link:../disci
       hono:
-        specifier: ^3.5.4
-        version: 3.5.4
+        specifier: ^4.2.5
+        version: 4.2.5
 
   packages/create-disci:
     dependencies:
@@ -234,12 +234,18 @@ packages:
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
+    peerDependenciesMeta:
+      '@algolia/client-search':
+        optional: true
 
   '@algolia/autocomplete-shared@1.9.3':
     resolution: {integrity: sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==}
     peerDependencies:
       '@algolia/client-search': '>= 4.9.1 < 6'
       algoliasearch: '>= 4.9.1 < 6'
+    peerDependenciesMeta:
+      '@algolia/client-search':
+        optional: true
 
   '@algolia/cache-browser-local-storage@4.19.1':
     resolution: {integrity: sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==}
@@ -3840,13 +3846,15 @@ snapshots:
   '@algolia/autocomplete-preset-algolia@1.9.3(@algolia/client-search@4.23.2)(algoliasearch@4.19.1)':
     dependencies:
       '@algolia/autocomplete-shared': 1.9.3(@algolia/client-search@4.23.2)(algoliasearch@4.19.1)
-      '@algolia/client-search': 4.23.2
       algoliasearch: 4.19.1
+    optionalDependencies:
+      '@algolia/client-search': 4.23.2
 
   '@algolia/autocomplete-shared@1.9.3(@algolia/client-search@4.23.2)(algoliasearch@4.19.1)':
     dependencies:
-      '@algolia/client-search': 4.23.2
       algoliasearch: 4.19.1
+    optionalDependencies:
+      '@algolia/client-search': 4.23.2
 
   '@algolia/cache-browser-local-storage@4.19.1':
     dependencies:
@@ -3854,7 +3862,8 @@ snapshots:
 
   '@algolia/cache-common@4.19.1': {}
 
-  '@algolia/cache-common@4.23.2': {}
+  '@algolia/cache-common@4.23.2':
+    optional: true
 
   '@algolia/cache-in-memory@4.19.1':
     dependencies:
@@ -3882,6 +3891,7 @@ snapshots:
     dependencies:
       '@algolia/requester-common': 4.23.2
       '@algolia/transporter': 4.23.2
+    optional: true
 
   '@algolia/client-personalization@4.19.1':
     dependencies:
@@ -3900,10 +3910,12 @@ snapshots:
       '@algolia/client-common': 4.23.2
       '@algolia/requester-common': 4.23.2
       '@algolia/transporter': 4.23.2
+    optional: true
 
   '@algolia/logger-common@4.19.1': {}
 
-  '@algolia/logger-common@4.23.2': {}
+  '@algolia/logger-common@4.23.2':
+    optional: true
 
   '@algolia/logger-console@4.19.1':
     dependencies:
@@ -3915,7 +3927,8 @@ snapshots:
 
   '@algolia/requester-common@4.19.1': {}
 
-  '@algolia/requester-common@4.23.2': {}
+  '@algolia/requester-common@4.23.2':
+    optional: true
 
   '@algolia/requester-node-http@4.19.1':
     dependencies:
@@ -3932,6 +3945,7 @@ snapshots:
       '@algolia/cache-common': 4.23.2
       '@algolia/logger-common': 4.23.2
       '@algolia/requester-common': 4.23.2
+    optional: true
 
   '@babel/code-frame@7.25.7':
     dependencies:


### PR DESCRIPTION
Hono recommends to use `hono/factory` instead of manually typing the request handler. this pr introduces this and also updates it to `v4.6.6`. [Hono docs](https://hono.dev/docs/guides/best-practices#factory-createhandlers-in-hono-factory)


Note: for some reason, all versions below `v4.6.6` there is a typescript error when using the `hono/factory` to create a handler.